### PR TITLE
fix: guard against empty choices and message=None in LLM client

### DIFF
--- a/packages/core/verbatim_core/llm_client.py
+++ b/packages/core/verbatim_core/llm_client.py
@@ -78,6 +78,8 @@ class LLMClient:
             kwargs["response_format"] = {"type": "json_object"}
 
         response = self.client.chat.completions.create(**kwargs)
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
 
     async def complete_async(
@@ -110,6 +112,8 @@ class LLMClient:
             kwargs["response_format"] = {"type": "json_object"}
 
         response = await self.async_client.chat.completions.create(**kwargs)
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
 
     def extract_spans(self, question: str, documents: Dict[str, str]) -> Dict[str, List[str]]:


### PR DESCRIPTION
## What

Add guards in `LLMClient.complete()` and `LLMClient.complete_async()` before accessing `response.choices[0].message.content`.

## Why

`chat.completions.create()` can return two empty-response shapes, both unhandled:

1. **`choices = []`** — on content-policy rejections, rate-limit errors, or provider failures
2. **`choices[0].message = None`** — Gemini 2.5 Flash (via the OpenAI-compatible endpoint) returns HTTP 200 with `finish_reason: PROHIBITED_CONTENT` and `message=None` rather than raising an exception

Both crash with `IndexError` or `AttributeError`. For a hallucination-prevention RAG system that may query multiple providers, silent crashes degrade the reliability guarantees the library is designed to provide.

## Change

```python
# Before
return response.choices[0].message.content

# After
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
return response.choices[0].message.content
```

Applied to both `complete()` (sync) and `complete_async()` (async).

## Corpus context

Detected by [`pact`](https://github.com/qizwiz/pact) (`llm_response_unguarded` mode), a Z3-verified static analyzer for LLM crash vectors. This pattern was found across 13.7k violations in 786 repos.