### PR TITLE
fix: transparent static template framing for machine consumption

### DIFF
--- a/docs/guide/verbatim-core.md
+++ b/docs/guide/verbatim-core.md
@@ -153,7 +153,7 @@ Controls how extracted spans are formatted into responses.
 
 ### Static Templates
 
-Fast, deterministic -- no LLM calls:
+Fast, deterministic -- no LLM calls. Static mode is the recommended choice for pipeline and tool-chain use cases where output is consumed by downstream tools or agents. The default template frames output transparently as an unordered list of verbatim excerpts with no synthesis or ranking implied, avoiding misleading machine consumers:
 
 ```python
 from verbatim_core.templates import TemplateManager

--- a/docs/guide/verbatim-core.md
+++ b/docs/guide/verbatim-core.md
@@ -153,7 +153,9 @@ Controls how extracted spans are formatted into responses.
 
 ### Static Templates
 
-Fast, deterministic -- no LLM calls. Static mode is the recommended choice for pipeline and tool-chain use cases where output is consumed by downstream tools or agents. The default template frames output transparently as an unordered list of verbatim excerpts with no synthesis or ranking implied, avoiding misleading machine consumers:
+Fast, deterministic -- no LLM calls. Static mode is the recommended choice for pipeline and tool-chain use cases where output is consumed by downstream tools or agents.
+
+The default template frames output transparently as an unordered list of verbatim excerpts with no synthesis or ranking implied, avoiding misleading machine consumers:
 
 ```python
 from verbatim_core.templates import TemplateManager

--- a/packages/core/verbatim_core/templates/static.py
+++ b/packages/core/verbatim_core/templates/static.py
@@ -22,7 +22,7 @@ class StaticTemplate(TemplateStrategy):
 
     DEFAULT_TEMPLATE = """## Response
 
-Based on the available documents, here are the key findings:
+The following is an unordered list of verbatim excerpts from the source documents. No synthesis or ranking is implied:
 
 [DISPLAY_SPANS]
 
@@ -125,7 +125,7 @@ Based on the available documents, here are the key findings:
         :param outro: Optional conclusion text
         :return: New StaticTemplate instance
         """
-        intro = intro or "Based on the available documents:"
+        intro = intro or "Verbatim excerpts from the source documents (unordered):"
         parts = [intro, "", "[DISPLAY_SPANS]"]
 
         if outro:


### PR DESCRIPTION
## Summary

Rewords `StaticTemplate.DEFAULT_TEMPLATE` to make explicit that static mode output is an **unordered list of verbatim excerpts** with no synthesis or ranking implied. The previous wording ("Based on the available documents, here are the key findings") implied a composed answer, which is misleading for machine consumers.

## Changes

- **`packages/core/verbatim_core/templates/static.py`**: Updated `DEFAULT_TEMPLATE` and `create_simple()` default intro to use transparent, machine-friendly language.
- **`docs/guide/verbatim-core.md`**: Documented static mode as the recommended choice for pipeline and tool-chain use.

## Verification

- All 94 tests pass (`pytest tests/ -v`)
- `ruff check` passes with no issues

## Rights & sign-off (required)

- [x] I certify that I have the right to submit this code and that it may be
      distributed under the repository's MIT license
      (see [CONTRIBUTING](../CONTRIBUTING.md#contribution-rights)).

Closes #35