### PR TITLE
fix: surface model extractor fallback warnings

### DIFF
--- a/packages/core/verbatim_core/extractor_models/dataset.py
+++ b/packages/core/verbatim_core/extractor_models/dataset.py
@@ -1,9 +1,12 @@
+import logging
 from dataclasses import dataclass
 from typing import Literal
 
 import torch
 from torch.utils.data import Dataset
 from transformers import AutoTokenizer
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -168,6 +171,11 @@ class QADataset(Dataset):
             # +1 for [SEP] token
             if len(input_ids) + len(sent_ids) + 1 > max_length:
                 # If this sentence won't fit, stop processing more sentences
+                logger.warning(
+                    "Legacy QA input exceeded the %d-token budget; dropping %d sentence(s)",
+                    max_length + 2,
+                    len(sentences) - len(sentence_boundaries),
+                )
                 break
 
             # If we get here, we can add the sentence

--- a/packages/core/verbatim_core/extractors.py
+++ b/packages/core/verbatim_core/extractors.py
@@ -145,7 +145,7 @@ class ModelSpanExtractor(SpanExtractor):
             if target and "Highlighter" in target:
                 return ModelSpanExtractor._FORMAT_HIGHLIGHTER
         except Exception as exc:
-            logger.debug("Highlighter detection failed for %s: %s", model_path, exc)
+            logger.warning("Highlighter detection failed for %s: %s", model_path, exc)
         return ModelSpanExtractor._FORMAT_QA_MODEL
 
     def _init_highlighter(self, model_path: str) -> None:

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,8 +1,86 @@
-"""Tests for verbatim_core.extractors (LLMSpanExtractor only)."""
+"""Tests for verbatim_core.extractors."""
 
+import importlib
+import logging
+import sys
+import types
 from unittest.mock import MagicMock
 
-from verbatim_core.extractors import LLMSpanExtractor
+from verbatim_core.extractors import LLMSpanExtractor, ModelSpanExtractor
+
+
+class TestModelSpanExtractorWarnings:
+    def test_detection_failure_warns_before_legacy_fallback(self, caplog, monkeypatch):
+        class FailingAutoConfig:
+            @staticmethod
+            def from_pretrained(*args, **kwargs):
+                raise RuntimeError("offline config")
+
+        transformers = types.ModuleType("transformers")
+        transformers.AutoConfig = FailingAutoConfig
+        monkeypatch.setitem(sys.modules, "transformers", transformers)
+
+        with caplog.at_level(logging.WARNING, logger="verbatim_core.extractors"):
+            result = ModelSpanExtractor._detect_format("org/highlighter")
+
+        assert result == ModelSpanExtractor._FORMAT_QA_MODEL
+        assert "Highlighter detection failed for org/highlighter: offline config" in caplog.text
+
+    def test_legacy_token_budget_warns_when_sentences_are_dropped(self, caplog, monkeypatch):
+        class FakeDataset:
+            pass
+
+        class FakeTensor(list):
+            pass
+
+        class FakeTokenizer:
+            sep_token_id = 2
+
+            def encode_plus(self, text, **kwargs):
+                size = 2 if kwargs.get("add_special_tokens") else len(text.split())
+                return {
+                    "input_ids": list(range(size)),
+                    "attention_mask": [1] * size,
+                    "offset_mapping": [(0, 1)] * size,
+                }
+
+        torch = types.ModuleType("torch")
+        torch.long = "long"
+        torch.tensor = lambda values, dtype=None: FakeTensor(values)
+        torch_utils = types.ModuleType("torch.utils")
+        torch_utils_data = types.ModuleType("torch.utils.data")
+        torch_utils_data.Dataset = FakeDataset
+        torch.utils = torch_utils
+        torch_utils.data = torch_utils_data
+        transformers = types.ModuleType("transformers")
+        transformers.AutoTokenizer = object
+
+        monkeypatch.setitem(sys.modules, "torch", torch)
+        monkeypatch.setitem(sys.modules, "torch.utils", torch_utils)
+        monkeypatch.setitem(sys.modules, "torch.utils.data", torch_utils_data)
+        monkeypatch.setitem(sys.modules, "transformers", transformers)
+        monkeypatch.delitem(sys.modules, "verbatim_core.extractor_models.dataset", raising=False)
+        dataset = importlib.import_module("verbatim_core.extractor_models.dataset")
+
+        sample = dataset.QASample(
+            question="question",
+            documents=[
+                dataset.Document(
+                    [
+                        dataset.Sentence("one two", False, "1"),
+                        dataset.Sentence("three four five", False, "2"),
+                    ]
+                )
+            ],
+            split="test",
+            dataset_name="inference",
+            task_type="qa",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="verbatim_core.extractor_models.dataset"):
+            dataset.QADataset([sample], FakeTokenizer(), max_length=7)[0]
+
+        assert "exceeded the 7-token budget; dropping 1 sentence(s)" in caplog.text
 
 
 class TestVerifySpans:


### PR DESCRIPTION
## What

Format-detection errors and legacy token-budget truncation now emit warnings instead of silently falling back or dropping sentences. Adds regression coverage for both paths.

Fixes #33

## Checklist

- [x] `pytest tests/ -v` passes
- [x] `ruff check packages/core/verbatim_core/ verbatim_rag/ api/ tests/` and
      `ruff format packages/core/verbatim_core/ verbatim_rag/ api/ tests/` pass
- [x] Tests added/updated for behavior changes
- [ ] Docs updated if user-facing (README / docs/ / docstrings)

## Rights & sign-off (required)

- [x] I certify that I have the right to submit this code and that it may be
      distributed under the repository's MIT license
      (see [CONTRIBUTING](../CONTRIBUTING.md#contribution-rights)).
