### PR TITLE
chore: strengthen repository foundations and define public roadmap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,23 +1,82 @@
 name: Bug report
-description: Something doesn't work as documented
+description: Report reproducible behavior that differs from the documentation
+title: "Bug: "
 type: Bug
+labels: [bug]
 body:
-  - type: textarea
-    id: what
+  - type: markdown
     attributes:
-      label: What happened
-      description: What you did, what you expected, what you got.
-    validations: {required: true}
+      value: |
+        Thanks for reporting a problem. Please remove credentials and private
+        document content from reproductions and logs.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which public surface is affected?
+      options:
+        - verbatim-core transform or templates
+        - Span extractor (LLM, ModernBERT, or Zilliz)
+        - Full verbatim-rag retrieval pipeline
+        - Ingestion, embeddings, or vector store
+        - CLI
+        - FastAPI API
+        - Frontend
+        - Installation or packaging
+        - Documentation or example
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: Include the package version or commit, Python version, and relevant model id.
+      placeholder: "verbatim-rag 0.2.8, Python 3.11, KRLabsOrg/verbatim-rag-modern-bert-v2"
+    validations:
+      required: true
+
+  - type: input
+    id: install
+    attributes:
+      label: Installation method
+      description: PyPI, editable checkout, Docker, or another method; include the exact command when possible.
+      placeholder: 'pip install "verbatim-core[model]==0.2.8"'
+    validations:
+      required: true
+
   - type: textarea
     id: repro
     attributes:
       label: Minimal reproduction
-      description: Smallest code/command that shows the problem.
+      description: Provide the smallest redacted code sample and command that reproduces the problem.
       render: python
-    validations: {required: true}
-  - type: input
-    id: version
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
     attributes:
-      label: verbatim-rag version + Python version
-      placeholder: "verbatim-rag 0.2.8, Python 3.11, macOS, pymilvus 2.x / torch 2.x if relevant"
-    validations: {required: true}
+      label: Expected behavior
+      description: What should have happened? Link the documentation or API contract when relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and logs
+      description: Include the complete traceback or unexpected output after removing secrets and private source text.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: OS, CPU/GPU, dependency versions, extractor, template mode, and span-match mode when relevant.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: Questions & discussion
-    url: https://github.com/KRLabsOrg/verbatim-rag/discussions
-    about: Ask questions and discuss ideas that aren't bugs or feature requests.
+  - name: Questions and support
+    url: https://github.com/KRLabsOrg/verbatim-rag/discussions/categories/q-a
+    about: Ask how to use Verbatim RAG or troubleshoot a setup before filing a bug.
+  - name: Early-stage idea
+    url: https://github.com/KRLabsOrg/verbatim-rag/discussions/categories/ideas
+    about: Explore an uncertain integration, research direction, or product idea before scoping an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,15 +1,67 @@
 name: Feature request
-description: Propose an improvement or new capability
+description: Propose an improvement grounded in a concrete workflow
+title: "Feature: "
 type: Feature
+labels: [enhancement]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Start with the workflow and evidence need. Larger or uncertain ideas are
+        often better opened in Discussions before they become implementation issues.
+
   - type: textarea
     id: problem
     attributes:
-      label: Problem
-      description: What can't you do today? Concrete use case beats abstract capability.
-    validations: {required: true}
+      label: Problem or use case
+      description: What are you trying to do, for whom, and what is difficult today?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Proposed surface
+      options:
+        - verbatim-core transform or templates
+        - Span extraction or validation
+        - Full verbatim-rag pipeline
+        - Evaluation or training
+        - Integration
+        - API or frontend
+        - Documentation
+        - Other / unsure
+    validations:
+      required: true
+
   - type: textarea
     id: proposal
     attributes:
-      label: Proposed solution
-      description: Rough API/behavior sketch. Alternatives you considered.
+      label: Proposed behavior
+      description: Sketch the API or observable behavior. A short example is useful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: success
+    attributes:
+      label: Success criteria
+      description: How would we know this solves the workflow without weakening provenance or compatibility?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives and non-goals
+      description: Workarounds considered and what this request should deliberately not include.
+    validations:
+      required: false
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Example or evidence
+      description: Link a reproducible workload, benchmark, design note, or minimal example if one exists.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,10 +1,68 @@
 name: Contributor task
-description: A scoped piece of work (used by maintainers to invite contributions)
+description: A bounded task prepared by a maintainer for implementation
+title: "Task: "
 type: Task
 body:
-  - type: textarea
-    id: body
+  - type: markdown
     attributes:
-      label: Task
-      description: "Problem, current behavior (file:line), steps, acceptance criteria, and a Start-here command."
-    validations: {required: true}
+      value: |
+        This form is primarily for maintainers preparing contributor-ready work.
+        A `good first issue` must be independently testable and small enough for a focused PR.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem and user impact
+      description: Explain why the current behavior matters.
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behavior and code pointers
+      description: Include verified file paths, symbols, and line references or commands.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Describe the smallest implementation that resolves the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Use observable, testable outcomes; include compatibility and failure behavior.
+      placeholder: "- [ ] ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: State nearby work that should not be folded into this issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Name the unit/integration tests, fixtures, docs, or benchmark expected in the PR.
+    validations:
+      required: true
+
+  - type: textarea
+    id: start
+    attributes:
+      label: Start here
+      description: Give one command and the first files or symbols to inspect.
+      render: shell
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,41 @@
-## What
+## Summary
 
-<!-- What does this PR do, and why? Link the issue: Fixes #NN -->
+<!-- What changes, why, and what user-visible outcome should reviewers verify? -->
+
+## Related issue
+
+<!-- Link the scoped issue, for example: Fixes #123. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Tests
+- [ ] Refactor or maintenance
+
+## Provenance and compatibility
+
+<!-- If extraction, validation, templates, citations, schemas, or defaults change,
+describe the guarantee and compatibility impact. Otherwise write "Not applicable". -->
+
+## Verification
+
+<!-- List the exact commands and focused cases you ran. Delete commands that are not relevant. -->
+
+- [ ] `pytest tests/ -v`
+- [ ] `ruff format --check packages/core/verbatim_core/ verbatim_rag/ api/ tests/`
+- [ ] `ruff check packages/core/verbatim_core/ verbatim_rag/ api/ tests/`
+- [ ] Frontend changes: `cd frontend && npm ci && npm run build`
+- [ ] Packaging changes: `python -m build packages/core && python -m build .`
+- [ ] Other:
 
 ## Checklist
 
-- [ ] `pytest tests/ -v` passes
-- [ ] `ruff check packages/core/verbatim_core/ verbatim_rag/ api/ tests/` and
-      `ruff format packages/core/verbatim_core/ verbatim_rag/ api/ tests/` pass
-- [ ] Tests added/updated for behavior changes
-- [ ] Docs updated if user-facing (README / docs/ / docstrings)
+- [ ] I kept the PR focused on one issue or decision.
+- [ ] I added or updated tests for behavior changes.
+- [ ] I updated public docs and the changelog for user-facing changes.
+- [ ] I did not include secrets, API keys, model credentials, or private source text.
 
 ## Rights & sign-off (required)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,18 @@ jobs:
       - run: pip install -e packages/core/
       - run: pytest tests/ -v
 
+  package-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build twine
+      - run: python -m build packages/core
+      - run: python -m build .
+      - run: twine check packages/core/dist/* dist/*
+
   pip-audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,20 +1,47 @@
-name: Deploy Docs
+name: Docs
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "packages/core/**"
+      - "verbatim_rag/**"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
   push:
     branches: [main]
     paths:
       - "docs/**"
       - "mkdocs.yml"
       - "packages/core/**"
+      - "verbatim_rag/**"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material "mkdocstrings[python]>=0.24"
+      - run: pip install -e packages/core/
+      - run: mkdocs build --strict
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,72 +1,136 @@
 # Contributing to Verbatim RAG
 
-Thanks for your interest in contributing!
+Thanks for your interest in contributing. Verbatim has a lightweight extraction
+package and a broader reference RAG stack, so first identify which surface your
+change affects.
 
-## Development Setup
+## Repository structure
+
+```text
+packages/core/verbatim_core/   # verbatim-core: question + context -> cited excerpts
+verbatim_rag/                  # verbatim-rag: retrieval, indexing, and orchestration
+api/                           # FastAPI development surface
+frontend/                      # Vite/React development UI
+tests/                         # network-free verbatim-core tests
+docs/                          # MkDocs documentation
+```
+
+Research training and canonical paper evaluation live in
+[`KRLabsOrg/acl-verbatim`](https://github.com/KRLabsOrg/acl-verbatim), not in
+the supported runtime API of this repository.
+
+## Setup
+
+Create a Python 3.10+ virtual environment, then install the surface you need.
 
 ```bash
 git clone https://github.com/KRLabsOrg/verbatim-rag.git
 cd verbatim-rag
+python -m venv .venv
+source .venv/bin/activate
+
+# Lightweight extraction development
+pip install -e packages/core/
+pip install pytest pytest-asyncio ruff build twine
+
+# Full RAG package development
 pip install -e packages/core/
 pip install -e ".[dev]"
 ```
 
-## Project Structure
+The core runtime depends on `openai`, `pydantic`, `rapidfuzz`, and `jinja2`.
+The optional model extra and full RAG package add substantially heavier ML,
+document-processing, and vector-store dependencies.
 
-```
-packages/core/verbatim_core/   # Lean extraction package (verbatim-core on PyPI)
-verbatim_rag/                  # Full RAG pipeline (verbatim-rag on PyPI)
-api/                           # FastAPI server
-frontend/                      # React UI
-tests/                         # Tests (run against verbatim-core only)
-docs/                          # MkDocs documentation
-```
+## Verification
 
-## Running Tests
+Run the checks that match the files you changed and list the exact commands in
+your pull request.
 
 ```bash
 pytest tests/ -v
+ruff format --check packages/core/verbatim_core/ verbatim_rag/ api/ tests/
+ruff check packages/core/verbatim_core/ verbatim_rag/ api/ tests/
 ```
 
-Tests only depend on `verbatim-core` (openai + pydantic). All LLM calls are mocked.
-
-## Linting
+For packaging changes:
 
 ```bash
-ruff check packages/core/verbatim_core/ verbatim_rag/ api/ tests/
-ruff format packages/core/verbatim_core/ verbatim_rag/ api/ tests/
+python -m build packages/core
+python -m build .
 ```
 
-## Making Changes
+For frontend changes:
 
-1. Fork the repo and create a branch from `main`
-2. Make your changes
-3. Run tests and linting
-4. Open a pull request against `main`
+```bash
+cd frontend
+npm ci
+npm run build
+```
 
-CI runs lint, tests (Python 3.10-3.12), and pip-audit on all PRs.
+CI currently gates the network-free `verbatim-core` tests on Python 3.10–3.12,
+Ruff across the core, full-RAG and API Python sources, dependency auditing for
+the core package, and distribution builds. A green core test matrix does not by
+itself validate model downloads, the API, or the frontend; include focused
+tests for those surfaces in the same PR.
 
-## Releasing
+## Issues and discussions
 
-Both packages share the same version number. To release:
+Use [Discussions](https://github.com/KRLabsOrg/verbatim-rag/discussions) for
+questions, early designs, research directions, and uncertain product ideas. Use
+an issue for a reproducible bug or a bounded implementation with testable
+acceptance criteria.
 
-1. Bump version in `packages/core/pyproject.toml` and `pyproject.toml`
-2. Update `CHANGELOG.md`
-3. Commit, tag, and push: `git tag v0.x.y && git push --tags`
-4. Create a GitHub release from the tag
-5. Publish to PyPI (extractor first, then rag):
-   ```bash
-   cd packages/core && python -m build && twine upload dist/*
-   cd ../.. && python -m build && twine upload dist/*
-   ```
+Labels clarify readiness:
+
+- `good first issue` is a small, independently testable change with code
+  pointers, non-goals, and a start command;
+- `help wanted` is ready for outside implementation or investigation but may
+  require more context than a first issue;
+- `design` needs an interface or behavior decision before implementation;
+- `research` is exploratory and may end in a negative result or design note;
+- `correctness` affects extraction, provenance, evaluation, or another stated
+  contract;
+- `status: claimed` means someone is actively working on it—coordinate before
+  starting a competing implementation.
+
+Comment on an unclaimed contributor issue before doing substantial work.
+Maintainers will assign it or add `status: claimed`. If the issue changes after
+investigation, post the evidence before expanding the PR.
+
+## Pull requests
+
+1. Branch from `main` and keep the PR focused on one issue or decision.
+2. Add tests for behavior and regression fixes.
+3. Explain any change to span validation, citations, templates, schemas,
+   defaults, or compatibility.
+4. Update public documentation and `CHANGELOG.md` for user-facing behavior.
+5. Remove credentials and private document text from tests, logs, and fixtures.
+6. Complete the contribution-rights checkbox in the PR template. CI enforces it.
 
 ## Contribution rights
 
 By submitting a pull request you confirm that you wrote the contribution (or
 have the right to submit it) and that it may be distributed under this
-repository's MIT license (this is what the checkbox in the PR template
-attests). Optionally you can also sign off commits with `git commit -s`
+repository's MIT license. This is what the required checkbox in the PR template
+attests. You may also sign off commits with `git commit -s`
 ([DCO](https://developercertificate.org/)); appreciated, not required.
+
+## Releasing
+
+`verbatim-core` and `verbatim-rag` currently share a version number.
+
+1. Update `packages/core/pyproject.toml`, `pyproject.toml`, and
+   `verbatim_rag/__init__.py` together.
+2. Update `CHANGELOG.md`.
+3. Build both distributions and inspect them.
+4. Tag the release and publish `verbatim-core` before `verbatim-rag`.
+
+```bash
+python -m build packages/core
+python -m build .
+twine check packages/core/dist/* dist/*
+```
 
 ## Code of Conduct
 

--- a/PUBLIC_ROADMAP.md
+++ b/PUBLIC_ROADMAP.md
@@ -1,0 +1,69 @@
+# Verbatim RAG roadmap
+
+Verbatim RAG is evidence-driven. This roadmap separates correctness work on
+the existing extraction contract from product directions that still need real
+workloads and contributor feedback. It intentionally has no delivery dates.
+
+## Vision
+
+Verbatim is a provenance-first answer layer: given a question and source
+context, it returns source excerpts with structured citations while minimizing
+the amount of freely generated factual text.
+
+The enforceable guarantee is about evidence provenance, not truth. Verbatim can
+show that a cited excerpt came from supplied source text; it cannot guarantee
+that the source is correct, retrieval is complete, or an extracted passage is
+the best answer. Contextual template mode can also generate presentation text
+around the cited excerpts. Static template mode keeps that framing fixed and
+transparent.
+
+## Now: [v0.3 — Trustworthy extraction](https://github.com/KRLabsOrg/verbatim-rag/milestone/1)
+
+This milestone tightens behavior that matters whichever product surface proves
+useful:
+
+- [surface model-format detection failures](https://github.com/KRLabsOrg/verbatim-rag/issues/33)
+  instead of silently selecting an incompatible extractor;
+- [make fuzzy validation asymmetric](https://github.com/KRLabsOrg/verbatim-rag/issues/34)
+  so permitted source-side markup can lower a score but changed content cannot
+  pass it;
+- [window the legacy sentence-model path](https://github.com/KRLabsOrg/verbatim-rag/issues/37)
+  while keeping the published v2 model's trusted remote windowing contract.
+
+The milestone is about extraction correctness and provenance. It does not
+commit a framework integration, ingestion product, or supported self-hosting
+surface.
+
+## Next: [Validation — Run it on your data](https://github.com/KRLabsOrg/verbatim-rag/milestone/2)
+
+[The evaluation harness](https://github.com/KRLabsOrg/verbatim-rag/issues/29)
+will make the published span metric reproducible on another corpus, including
+negative examples and per-example output. The aim is to learn where extraction
+is useful and where it fails before widening the API or training story.
+
+## Exploring
+
+These are open design questions, not promised release features:
+
+- a reproducible [local Docker Compose demo](https://github.com/KRLabsOrg/verbatim-rag/issues/27);
+- the right [adapter contract for an existing RAG stack](https://github.com/KRLabsOrg/verbatim-rag/issues/28);
+- a bounded [document-ingestion and lifecycle API](https://github.com/KRLabsOrg/verbatim-rag/issues/31);
+- supported domain adaptation for the current token-level extractors;
+- stable document identities and content hashes in citation records;
+- whether the main product pull is a reusable transform, curated hosted
+  collections, or a supported self-hosted pipeline.
+
+Exploring items move into a milestone only after a bounded contract and evidence
+from an actual workflow. Negative results and narrower designs are useful
+outcomes.
+
+## How this roadmap changes
+
+- Correctness work can move directly into the current release milestone.
+- Validation work must state its dataset, metric, split, and failure cases.
+- Product-surface work needs a scoped design and a user workflow before it is
+  treated as implementation-ready.
+- User-facing changes land with tests, documentation, and a changelog entry.
+- Ideas and early design feedback belong in
+  [Discussions](https://github.com/KRLabsOrg/verbatim-rag/discussions); scoped
+  implementation belongs in issues.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
   <br><em>Chill, I Ground! 🌶 ️</em>
 </p>
 
-A minimalistic approach to Retrieval-Augmented Generation (RAG) that prevents hallucination by ensuring all generated content is explicitly derived from source documents.
+Provenance-first extractive RAG: retrieve documents, select answer-relevant
+passages, and return source excerpts with citations instead of freely rewriting
+the evidence.
 
 [![PyPI](https://img.shields.io/pypi/v/verbatim-rag)](https://pypi.org/project/verbatim-rag/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
@@ -16,13 +18,39 @@ A minimalistic approach to Retrieval-Augmented Generation (RAG) that prevents ha
 
 ## Concept
 
-Traditional RAG systems retrieve relevant documents and then allow an LLM to freely generate responses based on that context. This can lead to hallucinations where the model invents facts not present in the source material.
+Traditional RAG systems retrieve relevant documents and then allow an LLM to
+freely generate a response. Verbatim RAG reduces that generative surface by
+selecting and displaying passages from retrieved context.
 
-Verbatim RAG solves this by extracting verbatim text spans from documents and composing responses entirely from these exact passages, with direct citations linking back to sources.
+Built-in verified extraction paths return evidence text from the supplied
+source. This is a provenance guarantee, not a truth guarantee: retrieval may be
+incomplete, a source may be wrong, and an extractor may choose an irrelevant or
+incomplete passage. The default contextual template may also generate
+presentation text around cited excerpts; use `template_mode="static"` when the
+framing must be fixed and deterministic.
 
-For extraction, we provide two 150M-parameter ModernBERT token classifiers that beat public extractive baselines (Zilliz Semantic Highlight, Provence) across ACL, RAGBench, Squeez, and QASPER — and outperform LLM-based extractors 100× their size on our ACL-Verbatim benchmark. See the [paper](https://arxiv.org/abs/2605.21102) and [HF collection](https://huggingface.co/collections/KRLabsOrg/verbatim-rag-v1) for details.
+On the paper's 100-row ACL-Verbatim benchmark, the 150M-parameter
+ACL-specialized model achieved **53.6 micro Word-F1**, compared with **48.7** for
+the strongest evaluated LLM extractor. In the generic v2
+[model-card evaluation](https://huggingface.co/KRLabsOrg/verbatim-rag-modern-bert-v2),
+v2 achieved higher micro Word-F1 than the evaluated Zilliz Semantic Highlight
+and Provence baselines on ACL, RAGBench, Squeez, and QASPER slices. See the
+[paper](https://arxiv.org/abs/2605.21102) for the benchmark design and
+limitations.
 
-With this approach, **the whole RAG pipeline can be run without any usage of LLMs**, and with SPLADE embeddings, the pipeline can be run entirely on CPU, making it lightweight and efficient.
+The pipeline can also use local encoder models for retrieval and extraction plus
+static rendering, without generative LLM API calls. With SPLADE and
+`ModelSpanExtractor`, that configuration supports CPU execution after model
+weights are available.
+
+## What "verbatim" means
+
+| Property | Built-in exact/static path | Outside the guarantee |
+|---|---|---|
+| Evidence text | Returned from retrieved source text | Custom/structured extractors must enforce their own contract |
+| Rendering | Exact excerpts plus fixed transparent framing | Contextual mode can generate introductions, labels, and connective text |
+| Citations | Source citations and highlights are returned | Repeated identical text can still make source-offset mapping ambiguous |
+| Correctness | Provenance can be inspected | Source truth, retrieval recall, relevance, completeness, and entailment |
 
 ## Installation
 
@@ -61,6 +89,16 @@ print(response.answer)
 ```
 
 Dependencies: only `openai`, `pydantic`, `rapidfuzz`, and `jinja2`.
+
+## Repository map
+
+| Surface | Location | Responsibility |
+|---|---|---|
+| `verbatim-core` | This repository, `packages/core/` | Reusable question + context → evidence transform, validation, templates, citations |
+| `verbatim-rag` | This repository, `verbatim_rag/` | Reference ingestion, indexing, retrieval, and orchestration pipeline |
+| Research/training | [`KRLabsOrg/acl-verbatim`](https://github.com/KRLabsOrg/acl-verbatim) | Paper reproduction, v2 training, datasets, and canonical evaluation |
+| Hosted client | [`KRLabsOrg/verbatim-client`](https://github.com/KRLabsOrg/verbatim-client) | SDK and CLI for hosted Verbatim services |
+| Agent adapters | [`KRLabsOrg/verbatim-mcp`](https://github.com/KRLabsOrg/verbatim-mcp), [`KRLabsOrg/verbatim-skill`](https://github.com/KRLabsOrg/verbatim-skill) | Thin MCP and agent integrations |
 
 ## Quick Start
 
@@ -126,7 +164,8 @@ export OPENAI_API_KEY=your_api_key_here
    - Responses are structured using templates
    - Citations link back to source documents
 
-This ensures all responses are grounded in the source material, preventing hallucinations.
+The evidence excerpts remain inspectable source text. Retrieval, extraction
+quality, and any generated contextual framing remain separate concerns.
 
 ## Architecture
 
@@ -146,27 +185,25 @@ This ensures all responses are grounded in the source material, preventing hallu
 3. User queries retrieve relevant documents
 4. Span extractors identify verbatim passages that answer the question
 5. Response templates structure the final answer with citations
-6. All responses include exact text spans and document references
+6. Responses expose selected source text with document references; guarantee
+   details depend on the extractor and template mode described above
 
-## Web Interface
+## API and web prototype
 
-The package includes a full web interface with React frontend and FastAPI backend:
-
-```bash
-# Start API server
-python api/app.py
-
-# Start React frontend (in another terminal)
-cd frontend/
-npm install
-npm start
-```
+The repository contains a FastAPI API and Vite/React development UI. They are
+not included in the PyPI wheel and are not yet part of the same compatibility
+gate as `verbatim-core`. Reproducible local-stack work is tracked in
+[#27](https://github.com/KRLabsOrg/verbatim-rag/issues/27), and the document
+lifecycle contract is tracked in
+[#31](https://github.com/KRLabsOrg/verbatim-rag/issues/31).
 
 ## ModernBERT Span Extractor
 
 [KRLabsOrg/verbatim-rag-modern-bert-v2](https://huggingface.co/KRLabsOrg/verbatim-rag-modern-bert-v2) is a 150M-parameter query-conditioned token classifier built on `gte-reranker-modernbert-base`. It supports up to 8,192 tokens and is trained on scientific papers, Wikipedia QA, financial tables, medical literature, legal contracts, product manuals, and code/tool output.
 
-It beats public extractive baselines (Zilliz Semantic Highlight, Provence) across ACL, RAGBench, Squeez, and QASPER. See the [paper](https://arxiv.org/abs/2605.21102) for full results.
+The linked model card reports higher micro Word-F1 than the evaluated Zilliz
+Semantic Highlight and Provence baselines on ACL, RAGBench, Squeez, and QASPER
+slices. These are extractor evaluations, not end-to-end hallucination rates.
 
 `ModelSpanExtractor` defaults to this model:
 
@@ -197,7 +234,12 @@ vector_store = LocalMilvusStore(
 )
 index = VerbatimIndex(vector_store=vector_store, sparse_provider=sparse_provider)
 
-rag_system = VerbatimRAG(index=index, extractor=extractor, k=5)
+rag_system = VerbatimRAG(
+    index=index,
+    extractor=extractor,
+    template_mode="static",  # no generated contextual framing
+    k=5,
+)
 response = rag_system.query("Main findings of the paper?")
 print(response.answer)
 ```
@@ -207,7 +249,7 @@ print(response.answer)
 | Resource | Link |
 |---|---|
 | 114K ACL Anthology papers in structured Markdown | [KRLabsOrg/acl-anthology-md](https://huggingface.co/datasets/KRLabsOrg/acl-anthology-md) |
-| 20K+ labelled query-chunk training pairs | [KRLabsOrg/verbatim-spans](https://huggingface.co/datasets/KRLabsOrg/verbatim-spans) |
+| Approximately 195K silver-labelled canonical query-chunk rows | [KRLabsOrg/verbatim-spans](https://huggingface.co/datasets/KRLabsOrg/verbatim-spans) |
 | Human-annotated ACL extraction benchmark | [KRLabsOrg/acl-verbatim-spans](https://huggingface.co/datasets/KRLabsOrg/acl-verbatim-spans) |
 | Training and evaluation pipeline | [KRLabsOrg/acl-verbatim](https://github.com/KRLabsOrg/acl-verbatim) |
 

--- a/api/app.py
+++ b/api/app.py
@@ -107,7 +107,7 @@ def create_app() -> FastAPI:
 
     app = FastAPI(
         title="Verbatim RAG API",
-        description="API for the Verbatim RAG system - prevents hallucination by extracting verbatim spans from documents",
+        description="API for provenance-first RAG with source excerpts and citations",
         version="1.0.0",
         lifespan=lifespan,
         debug=config.debug,

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -69,12 +69,13 @@ print(response.answer)
 
 ## Using the ModernBERT Extractor
 
-Replace the LLM-based extractor with a fine-tuned encoder model -- no API key needed:
+Replace the LLM-based extractor with the current v2 encoder model and static
+rendering—no generative LLM API call is made:
 
 ```python
 from verbatim_rag.extractors import ModelSpanExtractor
 
-extractor = ModelSpanExtractor("KRLabsOrg/verbatim-rag-modern-bert-v1")
-rag = VerbatimRAG(index, extractor=extractor)
+extractor = ModelSpanExtractor("KRLabsOrg/verbatim-rag-modern-bert-v2")
+rag = VerbatimRAG(index, extractor=extractor, template_mode="static")
 response = rag.query("Main findings?")
 ```

--- a/docs/guide/verbatim-rag.md
+++ b/docs/guide/verbatim-rag.md
@@ -68,9 +68,9 @@ store = CloudMilvusStore(
 ### Dense Embeddings
 
 ```python
-from verbatim_rag.embedding_providers import SentenceTransformerProvider
+from verbatim_rag.embedding_providers import SentenceTransformersProvider
 
-dense = SentenceTransformerProvider(model_name="all-MiniLM-L6-v2")
+dense = SentenceTransformersProvider(model_name="all-MiniLM-L6-v2")
 ```
 
 ### Sparse Embeddings (CPU-only)
@@ -119,8 +119,8 @@ Uses OpenAI models for extraction. Requires `OPENAI_API_KEY`.
 ```python
 from verbatim_rag.extractors import ModelSpanExtractor
 
-extractor = ModelSpanExtractor("KRLabsOrg/verbatim-rag-modern-bert-v1")
-rag = VerbatimRAG(index, extractor=extractor)
+extractor = ModelSpanExtractor("KRLabsOrg/verbatim-rag-modern-bert-v2")
+rag = VerbatimRAG(index, extractor=extractor, template_mode="static")
 ```
 
 ### Semantic Highlighting
@@ -134,12 +134,10 @@ extractor = SemanticHighlightExtractor(
 )
 ```
 
-## Web Interface
+## API and web prototype
 
-```bash
-# Start API server
-python api/app.py
-
-# Start React frontend
-cd frontend/ && npm install && npm start
-```
+The source tree includes a FastAPI API and Vite/React UI prototype. They are not
+part of the PyPI wheel or the current core compatibility gate. Follow
+[#27](https://github.com/KRLabsOrg/verbatim-rag/issues/27) for the reproducible
+local-stack work rather than treating these components as a supported
+production deployment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,8 @@
   <br><em>Chill, I Ground!</em>
 </p>
 
-A minimalistic approach to Retrieval-Augmented Generation (RAG) that prevents hallucination by ensuring all generated content is explicitly derived from source documents.
+Provenance-first extractive RAG: select answer-relevant source passages and
+return them with citations instead of freely rewriting the evidence.
 
 [![PyPI](https://img.shields.io/pypi/v/verbatim-rag)](https://pypi.org/project/verbatim-rag/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
@@ -15,22 +16,25 @@ A minimalistic approach to Retrieval-Augmented Generation (RAG) that prevents ha
 
 Traditional RAG systems retrieve relevant documents and then allow an LLM to freely generate responses based on that context. This can lead to hallucinations where the model invents facts not present in the source material.
 
-Verbatim RAG solves this by **extracting verbatim text spans** from documents and composing responses entirely from these exact passages, with direct citations linking back to sources.
+Verbatim RAG reduces unsupported generation by **extracting source passages**.
+Built-in verified paths return source text, but that contract does not guarantee
+source truth, retrieval recall, extraction relevance/completeness, or generated
+contextual framing. Use static templates for fixed deterministic framing.
 
 ## Two Packages
 
 | Package | Install | Dependencies | Use case |
 |---------|---------|-------------|----------|
 | **verbatim-rag** | `pip install verbatim-rag` | Full (torch, milvus, etc.) | Complete RAG pipeline with indexing, search, and extraction |
-| **verbatim-core** | `pip install verbatim-core` | Lean (openai, pydantic) | Reusable grounding core for integration into existing systems |
+| **verbatim-core** | `pip install verbatim-core` | Lean (openai, pydantic, rapidfuzz, jinja2) | Reusable evidence transform for integration into existing systems |
 
 ## Key Features
 
-- **Hallucination Prevention** -- All responses are grounded in exact source text
-- **Verbatim Extraction** -- Text spans are extracted exactly as they appear
-- **Citation Tracking** -- Every response includes precise document references
+- **Reduced generative surface** -- Return evidence instead of freely paraphrasing it
+- **Verbatim Extraction** -- Built-in verified paths return text from supplied sources
+- **Citation Tracking** -- Responses include source citations and highlights
 - **Multiple Extractors** -- LLM-based, fine-tuned ModernBERT, or Zilliz semantic highlighting
-- **CPU-Only Operation** -- Full pipeline can run without GPU using SPLADE embeddings
+- **Local static operation** -- SPLADE + ModernBERT + static templates can run without generative LLM API calls
 - **Template System** -- Flexible response formatting with multiple strategies
 
 ## How It Works

--- a/docs/verbatim_blog.md
+++ b/docs/verbatim_blog.md
@@ -1,20 +1,25 @@
 # Verbatim RAG: Stop Hallucinating, Start Quoting
 
+> **Historical design article.** Some APIs, model ids, benchmark counts, and
+> categorical claims below predate the current package. Use the repository
+> README and public roadmap for the supported guarantee boundary and current
+> model configuration.
+
 <p align="center">
   <img src="https://github.com/KRLabsOrg/verbatim-rag/blob/main/assets/chiliground.png?raw=true" alt="ChiliGround Logo" width="400"/>
   <br><em>Chill, I Ground!</em>
 </p>
 
 **TL;DR:**
-- **Extract, Don't Generate**: LLMs select exact text spans instead of generating -> zero hallucinations
+- **Extract, Don't Freely Rewrite**: select source text spans and keep the evidence inspectable
 - **Wrap Existing RAG**: Integrate with LangChain/LlamaIndex in 15 lines of code
 - **CPU-Only Pipeline**: No GPU, no API costs, works offline (SPLADE + ModernBERT) -> lightweight and efficient
 - **Template Control**: Static, dynamic, or question-specific response formatting
 - **Smart Chunking**: Structure-aware with raw/enhanced dual-chunk system
-- **Production-Ready**:
-  - Full RAG framework to get you started on your own project
-  - Scalable (optional) cloud based compute or local storage
-  - Included API and frontend for easy deployment
+- **Reference implementation**:
+  - Full RAG framework for experimentation
+  - Optional cloud compute or local storage
+  - API and frontend prototypes in the source repository
 
 **Quick Links:**
 - [⭐ GitHub](https://github.com/KRLabsOrg/verbatim-rag)
@@ -28,7 +33,10 @@
 
 The fundamental issue with RAG systems is that LLMs generate text probabilistically. Even when provided with perfect context, the model samples from a probability distribution over tokens, which inevitably introduces approximations, paraphrasing, and factual drift.
 
-This problem compounds in modern agentic RAG systems. When a single query triggers 7-8 sequential LLM calls (planning, retrieval, synthesis, verification, etc.), each with its own hallucination probability, the cumulative error rate becomes significant. If each call has a 10% chance of introducing an error, an 8-step agentic workflow has roughly a ~60% probability of containing at least one hallucination.
+This problem can compound in agentic RAG systems when a query triggers several
+generative steps. The practical risk depends on the models, prompts, task, and
+how failures correlate; it should be measured on the target workflow rather
+than inferred from a fixed per-call probability.
 
 **Verbatim RAG takes a different approach:** Instead of asking the LLM to generate an answer based on retrieved documents, we constrain it to **extract exact text spans** that answer the question. These spans are then composed into a response without any generative rewriting.
 
@@ -36,13 +44,17 @@ This problem compounds in modern agentic RAG systems. When a single query trigge
   <img src="https://github.com/KRLabsOrg/verbatim-rag/blob/main/assets/verbatim_architecture.png?raw=true" alt="Verbatim RAG Architecture" width="800"/>
 </p>
 
-**Why this works:** Extraction is a classification task (does this span answer the question?), not a generation task. The model never produces new tokens that approximate source content, it only identifies which existing tokens to include. This eliminates the issue of the probabilistic generation that causes hallucinations.
+**Why this helps:** Extraction asks which source spans answer the question rather
+than asking a model to freely rewrite the evidence. Built-in verified paths
+return source text, reducing the factual surface available for unsupported
+generation.
 
-The result: every number, every fact, every claim in the response is directly traceable to the source text.
+The result is inspectable evidence text. Source truth, retrieval completeness,
+selection relevance, and contextual framing still require evaluation.
 
 ---
 
-## Quickstart: Zero Hallucinations in 15 Lines
+## Quickstart: Source excerpts in 15 lines
 
 Install the required dependencies:
 ```bash
@@ -75,10 +87,10 @@ The system achieved 42.01% accuracy on ArchEHR-QA.
 )
 index.add_documents([doc])
 
-# 3. Create RAG with hallucination prevention
+# 3. Create the RAG pipeline
 rag = VerbatimRAG(index, model="gpt-4o-mini")
 
-# 4. Get exact quotes, not hallucinations
+# 4. Get source excerpts
 response = rag.query("What approaches were used?")
 print(response.answer)
 # [1] We used two approaches: zero-shot LLM extraction and a fine-tuned ModernBERT classifier on 58k synthetic examples.
@@ -210,7 +222,7 @@ Handles document ingestion, chunking, embedding, and retrieval:
 ### Layer 2: Verbatim Core (Extraction)
 Consumes retrieved chunks and produces verbatim answers:
 - **Input**: Query + retrieved chunks
-- **Output**: Answer composed entirely from extracted spans
+- **Output**: Source excerpts, with framing determined by the selected template mode
 - **Components**: Span extractors (LLM or fine-tuned models), template managers, verification
 
 ### The Interface
@@ -287,9 +299,10 @@ store = CloudMilvusStore(
 
 ---
 
-## CPU-Only Pipeline: No LLM API Calls
+## CPU-capable pipeline without generative LLM API calls
 
-The entire pipeline can run on CPU without GPU or LLM API calls:
+After model weights are available, retrieval and extraction can run on CPU
+without a generative LLM API call when static rendering is selected:
 
 ```python
 from verbatim_rag.extractors import ModelSpanExtractor
@@ -300,12 +313,12 @@ embedder = SpladeProvider("opensearch-project/opensearch-neural-sparse-encoding-
 
 # ModernBERT for extraction (fine-tuned on span classification)
 extractor = ModelSpanExtractor(
-    model_path="KRLabsOrg/verbatim-rag-modern-bert-v1",
+    model_path="KRLabsOrg/verbatim-rag-modern-bert-v2",
     device="cpu"
 )
 
 # Complete CPU-only RAG
-rag = VerbatimRAG(index, extractor=extractor)
+rag = VerbatimRAG(index, extractor=extractor, template_mode="static")
 ```
 
 **Tradeoffs**: The fine-tuned extractor has lower recall than LLM-based extractors on complex queries, but is deterministic, free, and works offline.
@@ -491,7 +504,7 @@ Verbatim RAG trades generation flexibility for factual precision. Use it when:
 - **Exactness matters**: Medical dosages, legal citations, financial figures must be character-perfect
 - **Auditability required**: Every claim needs to trace back to source text
 - **Liability concerns**: Approximate or paraphrased answers create legal/compliance risk
-- **Existing RAG needs hardening**: You have a working system but need to eliminate hallucinations
+- **Existing RAG needs a smaller generative surface**: You want inspectable source excerpts alongside your existing retrieval
 
 **When traditional RAG may be preferable:**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Verbatim RAG
-site_description: Hallucination-prevention RAG system with verbatim span extraction
+site_description: Provenance-first extractive RAG with source spans and citations
 site_url: https://krlabsorg.github.io/verbatim-rag/
 repo_url: https://github.com/krlabsorg/verbatim-rag
 repo_name: KRLabsOrg/verbatim-rag

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,9 @@
 
 Lightweight verbatim span extraction -- the RAG-agnostic core of [verbatim-rag](https://github.com/KRLabsOrg/verbatim-rag).
 
-Extract exact, verbatim text spans from documents that answer a question. No vector databases, no embeddings, no heavy ML dependencies -- just `openai` and `pydantic`.
+Extract source text spans from documents that answer a question. No vector
+databases, embeddings, or heavy ML dependencies by default—runtime dependencies
+are `openai`, `pydantic`, `rapidfuzz`, and `jinja2`.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "verbatim-rag"
 version = "0.2.8"
-description = "A minimalistic RAG system that prevents hallucination by ensuring all generated content is explicitly derived from source documents"
+description = "Provenance-first extractive RAG with verbatim source spans and citations"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/tests/test_version_metadata.py
+++ b/tests/test_version_metadata.py
@@ -1,0 +1,27 @@
+"""Keep the public package versions aligned without importing heavy dependencies."""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _project_version(path: Path) -> str:
+    project_section = path.read_text().split("[project]", 1)[1].split("\n[", 1)[0]
+    match = re.search(r'^version\s*=\s*"([^"]+)"', project_section, re.MULTILINE)
+    assert match is not None, f"No [project] version found in {path}"
+    return match.group(1)
+
+
+def _module_version(path: Path) -> str:
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', path.read_text(), re.MULTILINE)
+    assert match is not None, f"No __version__ found in {path}"
+    return match.group(1)
+
+
+def test_public_package_versions_match() -> None:
+    root_version = _project_version(ROOT / "pyproject.toml")
+    core_version = _project_version(ROOT / "packages" / "core" / "pyproject.toml")
+    module_version = _module_version(ROOT / "verbatim_rag" / "__init__.py")
+
+    assert root_version == core_version == module_version

--- a/verbatim_rag/__init__.py
+++ b/verbatim_rag/__init__.py
@@ -1,9 +1,6 @@
-"""
-Verbatim RAG - A minimalistic RAG system that prevents hallucination by ensuring all generated content
-is explicitly derived from source documents.
-"""
+"""Provenance-first RAG with verbatim evidence spans and citations."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.8"
 
 from verbatim_rag.core import VerbatimRAG as VerbatimRAG
 from verbatim_rag.document import Document as Document

--- a/verbatim_rag/core.py
+++ b/verbatim_rag/core.py
@@ -48,9 +48,11 @@ Mark the relevant text:
 
 
 class VerbatimRAG:
-    """
-    A RAG system that prevents hallucination by ensuring all generated content
-    is explicitly derived from source documents.
+    """Retrieve documents and compose cited source excerpts.
+
+    Built-in verified extractors preserve evidence text provenance. Retrieval
+    quality, source truth, extraction relevance, and generated contextual
+    framing remain outside that guarantee.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

Bring Verbatim RAG's public repository foundations up to the same standard as
RuleChef and LettuceDetect while keeping the roadmap intentionally lean.

- add an evidence-driven `PUBLIC_ROADMAP.md` linked to two undated milestones;
- scope the public promise to evidence provenance, with explicit static versus
  contextual template boundaries;
- replace the ambiguous model-size claim with the verified 53.6 versus 48.7
  micro Word-F1 result and identify the 100-row benchmark;
- document how `verbatim-core`, `verbatim-rag`, `acl-verbatim`, and the public
  adapters relate;
- expand bug, feature, contributor-task, and PR templates with reproducibility,
  acceptance, non-goal, provenance, testing, and rights fields;
- document issue readiness/claiming conventions in `CONTRIBUTING.md`;
- build and check both distributions in CI, and validate MkDocs on pull
  requests before deployment;
- align `verbatim_rag.__version__` with both 0.2.8 package metadata files and
  add a regression test;
- correct stale v1/static-mode/provider/UI documentation.

The GitHub repository description and existing issue bodies were triaged in
parallel. This PR does not add speculative full-stack issues or claim that the
currently ungated API/frontend are production-supported.

## Related issues and milestones

- [v0.3 — Trustworthy extraction](https://github.com/KRLabsOrg/verbatim-rag/milestone/1)
- [Validation — Run it on your data](https://github.com/KRLabsOrg/verbatim-rag/milestone/2)
- #27, #28, #29, #30, #31, #33, #34, #37

## Type of change

- [x] Documentation
- [x] Tests
- [x] Refactor or maintenance

## Provenance and compatibility

No extractor runtime behavior changes. Public wording now distinguishes source
span provenance from source truth, retrieval quality, extraction relevance,
and generated contextual framing. `verbatim_rag.__version__` is corrected from
the stale 0.1.0 value to the existing package version 0.2.8.

## Verification

- [x] `PYTHONPATH=packages/core python -m pytest tests/ -q` — 95 passed
- [x] `ruff format --check packages/core/verbatim_core/ verbatim_rag/ api/ tests/`
- [x] `ruff check packages/core/verbatim_core/ verbatim_rag/ api/ tests/`
- [x] `mkdocs build --strict`
- [x] built both sdists/wheels and ran `twine check` — all passed
- [x] parsed all four issue-form YAML files
- [x] `git diff --check`

The local pytest environment did not have `pytest-asyncio`, so pytest reported
one warning for the configured `asyncio_mode`; CI installs that plugin.

## Known follow-up scope

- Root dependency installation, API behavior, CLI commands, and the frontend
  still need dedicated compatibility gates after their verified baseline
  defects are scoped.
- The new distribution-build job should become a required status after it has
  run successfully on the merged workflow.

## Checklist

- [x] I kept the PR focused on repository truth, contributor foundations, and
      roadmap organization.
- [x] I did not include secrets, credentials, private notes, or customer data.
- [x] Public claims link to their primary paper/model resources.

## Rights & sign-off (required)

- [x] I certify that I have the right to submit this code and that it may be
      distributed under the repository's MIT license
      (see [CONTRIBUTING](../CONTRIBUTING.md#contribution-rights)).
