### PR TITLE
docs: use the current [SPAN_N] placeholder name in the core guide

### DIFF
--- a/docs/guide/verbatim-core.md
+++ b/docs/guide/verbatim-core.md
@@ -178,7 +178,8 @@ tm = TemplateManager(llm_client=client, default_mode="contextual")
 ### Template Placeholders
 
 - `[DISPLAY_SPANS]` -- all display spans aggregated
-- `[FACT_1]`, `[FACT_2]`, ... -- individual span placeholders
+- `[SPAN_1]`, `[SPAN_2]`, ... -- individual span placeholders
+  (`[FACT_N]` is the pre-0.2.7 name and still works in stored templates)
 - `[CITATION_REFS]` -- citation-only reference numbers
 
 ### Linked Citations


### PR DESCRIPTION
## Summary

`docs/guide/verbatim-core.md` still lists the per-span placeholders as `[FACT_1]`,
`[FACT_2]`. They were renamed to `[SPAN_N]` in 0.2.7: the bundled prompt now emits
`[SPAN_N]` (`packages/core/verbatim_core/prompts/template/per_fact.txt`), and the
validation error in `packages/core/verbatim_core/templates/base.py` already tells
users to use `[SPAN_1]`. `[FACT_N]` is still accepted, so this is stale guidance
rather than broken guidance — but the guide teaches a name the system no longer
produces.

The change is one line plus a parenthetical noting that `[FACT_N]` keeps working in
stored templates, which is what the 0.2.7 changelog entry promises.

`docs/verbatim_blog.md` uses the older `[RELEVANT_SENTENCES]` name in four places.
Left alone deliberately: that placeholder is still accepted, and the file already
carries a note that it predates the current package.

## Related issue

None — one-line documentation correction. The drift dates to the `[FACT_N]` →
`[SPAN_N]` rename in 0.2.7.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Tests
- [ ] Refactor or maintenance

## Provenance and compatibility

Not applicable — documentation only. No change to extraction, validation,
templates, citations, schemas, or defaults.

## Verification

- [x] Other: `mkdocs build --strict` — exits 0 with no warnings, and the rendered
      page shows the corrected placeholder names.

## Checklist

- [x] I kept the PR focused on one issue or decision.
- [ ] I added or updated tests for behavior changes — none, documentation only.
- [x] I updated public docs and the changelog for user-facing changes — this change
      *is* the documentation fix; no behavior changed, so no changelog entry.
- [x] I did not include secrets, API keys, model credentials, or private source text.

## Rights & sign-off (required)

- [x] I certify that I have the right to submit this code and that it may be
      distributed under the repository's MIT license
      (see [CONTRIBUTING](../CONTRIBUTING.md#contribution-rights)).
