### PR TITLE
fix: commit the missing shadcn/ui components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,7 @@ cython_debug/
 documents/
 index/
 templates.json
-ui/
+/ui/
 .ruff_cache/
 
 data/

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -12,6 +12,6 @@
   },
   "aliases": {
     "components": "src/components",
-    "utils": "src/lib/utils"
+    "utils": "src/utils/cn"
   }
 }

--- a/frontend/src/components/ui/badge.jsx
+++ b/frontend/src/components/ui/badge.jsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/utils/cn"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  ...props
+}) {
+  return (<div className={cn(badgeVariants({ variant }), className)} {...props} />);
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -1,0 +1,47 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/utils/cn"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const Button = React.forwardRef(({ className, variant, size, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button"
+  return (
+    <Comp
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      {...props} />
+  );
+})
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/frontend/src/components/ui/card.jsx
+++ b/frontend/src/components/ui/card.jsx
@@ -1,0 +1,50 @@
+import * as React from "react"
+
+import { cn } from "@/utils/cn"
+
+const Card = React.forwardRef(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+    {...props} />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props} />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+    {...props} />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props} />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props} />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/frontend/src/components/ui/input.jsx
+++ b/frontend/src/components/ui/input.jsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+import { cn } from "@/utils/cn"
+
+const Input = React.forwardRef(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      ref={ref}
+      {...props} />
+  );
+})
+Input.displayName = "Input"
+
+export { Input }

--- a/frontend/src/components/ui/scroll-area.jsx
+++ b/frontend/src/components/ui/scroll-area.jsx
@@ -1,0 +1,38 @@
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/utils/cn"
+
+const ScrollArea = React.forwardRef(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}>
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}>
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/frontend/src/components/ui/tooltip.jsx
+++ b/frontend/src/components/ui/tooltip.jsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/utils/cn"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+      className
+    )}
+    {...props} />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }


### PR DESCRIPTION
## Summary

`frontend/src/components/ui/` was never committed: the unscoped `ui/` rule at
`.gitignore:176` matched it at any depth, so `git add` skipped the six
shadcn/ui components that `ErrorBoundary` and `CleanFactInterface` import. On a
fresh clone `npm run build` aborts on the first unresolved import, which also
breaks the frontend Docker image build.

Three changes, exactly the ones in the issue body:

- **`.gitignore`** — anchor the rule to `/ui/`. Of the two options the issue
  offered, anchoring is the narrowest: it keeps a top-level `ui/` directory
  ignored (the apparent original intent — it was added next to `documents/`,
  `index/`, `.ruff_cache/`) while no longer matching source paths. A
  `!frontend/src/components/ui/` negation would have left the broad rule in
  place to catch the next `ui/` directory someone adds.
- **`frontend/components.json`** — the `utils` alias pointed at `src/lib/utils`,
  which does not exist; the project's helper is `src/utils/cn`. This does not
  affect the build (Vite resolves `@` from `vite.config.js`) — it just makes the
  shadcn config describe the repo as it is.
- **the six components** — `button`, `card`, `badge`, `input`, `scroll-area`,
  `tooltip`.

The components were generated with `npx shadcn add`, not hand-written. They
need no theme rewiring: `tailwind.config.js` already defines the CSS-variable
tokens they reference (`bg-primary`, `text-primary-foreground`, `border-input`,
…).

## Related issue

Fixes #42

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Tests
- [ ] Refactor or maintenance

## Provenance and compatibility

No change to extraction, validation, templates, citations, schemas or defaults —
this is frontend build plumbing only.

On provenance of the added files: shadcn/ui is MIT-licensed and distributed by
design as source copied into the consuming repository, so committing the
generated output here is the intended usage and is compatible with this repo's
MIT license.

## Verification

Run in a clean `git worktree` (not my working copy — the files exist there as
ignored-but-present, so a build in place would pass either way), Node 24.2.0.

Before, at `upstream/main`:

```console
$ cd frontend && npm ci && npm run build
error during build:
Could not resolve "./ui/button.jsx" from "src/components/ErrorBoundary.js"
```

After, at this branch, same worktree:

```console
$ npm run build
✓ 2348 modules transformed.
build/index.html                   1.22 kB │ gzip:   0.59 kB
build/assets/index-CxYj4Wwi.css   31.68 kB │ gzip:   6.38 kB
build/assets/index-Cw9TYpW8.js   564.53 kB │ gzip: 182.67 kB
✓ built in 2.00s
```

`npm run dev` also serves the app: `/` returns the app shell and
`/src/components/ui/button.jsx` transforms with 200.

- [ ] `pytest tests/ -v`
- [ ] `ruff format --check packages/core/verbatim_core/ verbatim_rag/ api/ tests/`
- [ ] `ruff check packages/core/verbatim_core/ verbatim_rag/ api/ tests/`
- [x] Frontend changes: `cd frontend && npm ci && npm run build`
- [ ] Packaging changes: `python -m build packages/core && python -m build .`
- [x] Other: `npm run dev` smoke check; `git check-ignore` confirms the path is
      no longer ignored and the six files stage without `git add -f`.

Python checks are not applicable — no Python file is touched.

## Checklist

- [x] I kept the PR focused on one issue or decision.
- [ ] I added or updated tests for behavior changes. — no test harness exists for
      the frontend; the build itself is the regression check.
- [ ] I updated public docs and the changelog for user-facing changes. —
      `CHANGELOG.md` tracks the released Python packages and has no Unreleased
      section; a frontend build fix has no entry there. Happy to add one if you
      keep frontend changes in it.
- [x] I did not include secrets, API keys, model credentials, or private source text.

## Rights & sign-off (required)

- [x] I certify that I have the right to submit this code and that it may be
      distributed under the repository's MIT license
      (see [CONTRIBUTING](CONTRIBUTING.md#contribution-rights)).
