### PR TITLE
build: default the published frontend port to 8080 everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ OPENAI_API_KEY=your_key_here docker compose up --build
 |---|---|---|
 | `OPENAI_API_KEY` | (required) | OpenAI-compatible API key |
 | `INDEX_PATH` | `/data/index.db` | Milvus Lite database path in the container |
-| `FRONTEND_PORT` | `80` | Host port the frontend is published on |
+| `FRONTEND_PORT` | `8080` | Host port the frontend is published on |
 
 All of these can be set in `.env` (copy `.env.example`) or exported in the
 shell. CORS configuration is not needed: the browser only talks to nginx, which
@@ -283,7 +283,7 @@ via its own proxy).
 
 ```mermaid
 graph LR
-    A[Browser] -->|http://localhost| B[nginx :80]
+    A[Browser] -->|http://localhost:8080| B[nginx :80]
     B -->|/api/*| C[FastAPI :8000]
     C --> D[(Milvus Lite<br>/data/index.db)]
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       dockerfile: Dockerfile
     container_name: verbatim-frontend
     ports:
-      - "${FRONTEND_PORT:-80}:80"
+      - "${FRONTEND_PORT:-8080}:80"
     depends_on:
       api:
         condition: service_healthy

--- a/docker/overrides.txt
+++ b/docker/overrides.txt
@@ -22,7 +22,7 @@
 # After regenerating, verify rather than trust the resolution:
 #
 #   docker compose up --build
-#   curl -fsS http://localhost/api/status
+#   curl -fsS http://localhost:8080/api/status
 
 # milvus-lite 3.x rejects collections that have no vector field:
 #


### PR DESCRIPTION
## Summary

Follow-up to the non-blocking nit in the #43 review: `FRONTEND_PORT` defaults
disagreed. `.env.example` and the README quickstart said 8080; the Compose
fallback (`${FRONTEND_PORT:-80}`) and the README configuration table said 80.
Now all of them say 8080, so a stack started without a `.env` no longer needs a
privileged port. The lock-regeneration hint in `docker/overrides.txt` now curls
`:8080` as well. Container-side port, nginx config and health checks are untouched.

## Related issue

Refs #27 (follow-up to #43).

## Type of change

- [x] Refactor or maintenance

## Provenance and compatibility

Not applicable — a deployment default only. Anyone who set `FRONTEND_PORT`
explicitly is unaffected.

## Verification

- [x] Other: `mv .env .env.bak && docker compose config` → frontend `published: "8080"`;
      `grep -n FRONTEND_PORT README.md docker-compose.yml .env.example` all say 8080.

## Checklist

- [x] I kept the PR focused on one issue or decision.
- [ ] I added or updated tests for behavior changes. (N/A — no code path)
- [x] I updated public docs and the changelog for user-facing changes. (README yes;
      no CHANGELOG line — the Unreleased entry describes the stack, not port numbers)
- [x] I did not include secrets, API keys, model credentials, or private source text.

## Rights & sign-off (required)

- [x] I certify that I have the right to submit this code and that it may be
      distributed under the repository's MIT license
      (see [CONTRIBUTING](../CONTRIBUTING.md#contribution-rights)).

