### PR TITLE
docs: name the default frontend port in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Docker Compose development and demo stack: the FastAPI API and the Vite/React UI run
-  locally behind nginx, which proxies `/api/` same-origin. Milvus Lite data persists on a
-  named volume. Not a production deployment — no TLS, authentication, tenancy, or scaling.
+  locally behind nginx, which proxies `/api/` same-origin, published on `:8080` by default
+  (`FRONTEND_PORT` overrides). Milvus Lite data persists on a named volume. Not a
+  production deployment — no TLS, authentication, tenancy, or scaling.
 - `docker/constraints.txt`: a checked-in dependency lock used only by the container image;
   the published ranges in `pyproject.toml` are unchanged. Pins `milvus-lite<3`, whose 3.x
   line rejects the vector-less metadata collection `LocalMilvusStore` creates.


### PR DESCRIPTION
## Summary

Follow-up to the #46 review: the `[Unreleased]` Compose bullet in `CHANGELOG.md`
now says the UI is published on `:8080` by default and that `FRONTEND_PORT`
overrides it. No other files change; README and `.env.example` already say this.

## Related issue

Refs #27 (follow-up to #46).

## Type of change

- [x] Documentation

## Provenance and compatibility

Not applicable.

## Verification

- [x] Other: `git diff` touches one bullet in `CHANGELOG.md`; the wording matches
      `docker-compose.yml` (`${FRONTEND_PORT:-8080}:80`) and the README table.

## Checklist

- [x] I kept the PR focused on one issue or decision.
- [x] I updated public docs and the changelog for user-facing changes.
- [x] I did not include secrets, API keys, model credentials, or private source text.

## Rights & sign-off (required)

- [x] I certify that I have the right to submit this code and that it may be
      distributed under the repository's MIT license
      (see [CONTRIBUTING](../CONTRIBUTING.md#contribution-rights)).
